### PR TITLE
Test harness case rename

### DIFF
--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace riedel::fabricsperf
 {
@@ -17,7 +18,7 @@ namespace riedel::fabricsperf
         bool reflector;
         std::string listen;
         std::string connect;
-        std::string run;
+        std::vector<std::string> run;
         std::string targetEndpoint;
         std::string initiatorEndpoint;
         std::string output;

--- a/src/Executor.cpp
+++ b/src/Executor.cpp
@@ -1,8 +1,5 @@
 #include "Executor.hpp"
 #include <exception>
-#include <fstream>
-#include "internal/Logging.hpp"
-#include "CSV.hpp"
 #include "Output.hpp"
 #include "Reflector.hpp"
 #include "Runner.hpp"
@@ -18,7 +15,7 @@ namespace riedel::fabricsperf
 
     void Executor::run()
     {
-        if (_config.run == "list")
+        if (_config.run.empty())
         {
             for (auto const& [name, _] : _factories)
             {
@@ -41,28 +38,21 @@ namespace riedel::fabricsperf
     {
         Results results;
 
-        if (_config.run == "all")
+        for (auto const& testCase : _config.run)
         {
-            for (auto& [name, factory] : _factories)
+            if (_stopped.load())
             {
-                if (_stopped.load())
-                {
-                    return;
-                }
-
-                _inner = std::make_unique<Runner>(_config, (*factory)(), name);
-                _inner->run();
-
-                results.emplace_back(name, dynamic_cast<Runner&>(*_inner).exportResults());
+                return;
             }
-        }
-        else
-        {
-            auto test = (*_factories.at(_config.run))();
-            _inner = std::make_unique<Runner>(_config, std::move(test), _config.run);
+
+            auto test = (*_factories.at(testCase))();
+            _inner = std::make_unique<Runner>(_config, std::move(test), testCase);
             _inner->run();
 
-            results.emplace_back(_config.run, dynamic_cast<Runner&>(*_inner).exportResults());
+            results.emplace_back(testCase, dynamic_cast<Runner&>(*_inner).exportResults());
+
+            _inner.reset(); // Destroy the previous Runner and all its child when we are done with
+                            // them.
         }
 
         writeResults(_config.output, std::move(results));

--- a/src/Executor.cpp
+++ b/src/Executor.cpp
@@ -15,20 +15,23 @@ namespace riedel::fabricsperf
 
     void Executor::run()
     {
-        if (_config.run.empty())
-        {
-            for (auto const& [name, _] : _factories)
-            {
-                std::cout << name << '\n';
-            }
-
-            return;
-        }
-
         auto mode = _config.mode();
         switch (mode)
         {
-            case Mode::RUNNER:    runner(); break;
+            case Mode::RUNNER: {
+                if (_config.run.empty())
+                {
+                    for (auto const& [name, _] : _factories)
+                    {
+                        std::cout << name << '\n';
+                    }
+
+                    return;
+                }
+
+                runner();
+                break;
+            }
             case Mode::REFLECTOR: reflector(); break;
             default:              std::terminate();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char** argv)
         .reflector = false,
         .listen = "",
         .connect = "",
-        .run = "all",
+        .run = {},
         .targetEndpoint = "127.0.0.1:9992",
         .initiatorEndpoint = "127.0.0.1:9993",
         .output = "output/",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,7 @@
 #include <mxl/mxl.h>
 #include "internal/Logging.hpp"
 #include "mxl/fabrics.h"
-#include "tests/MXLHost2Host.hpp"
+#include "tests/MXLFabrics.hpp"
 #include "tests/TestTemplateOneWay.hpp"
 #include "tests/TestTemplatePingPong.hpp"
 #include "Executor.hpp"
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
     app.add_option("-o, --output",
         config.output,
         "Directory at which the report should be written. Each test case will output a csv file "
-        "with the name of the test case. Ex: <output>/MXLHost2Host+Verbs+Reflect+Wait.csv");
+        "with the name of the test case. Ex: <output>/MXLFabrics+Host2Host+Verbs+Reflect+Wait.csv");
     app.add_option("-g, --gpu", config.gpu, "Id of the gpu that should be used");
     app.add_option("-r, --run",
         config.run,
@@ -64,26 +64,26 @@ int main(int argc, char** argv)
         fp::Executor runner{std::move(config)};
 
         // clang-format off
-        runner.add<fp::MXLHost2Host<"MXLHost2Host+Verbs+Reflect+Wait", fp::TransferMode::Reflect, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_VERBS, MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
-        runner.add<fp::MXLHost2Host<"MXLHost2Host+Verbs+Reflect+Spin", fp::TransferMode::Reflect, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_VERBS,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
-        runner.add<fp::MXLHost2Host<"MXLHost2Host+Verbs+OneWay+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_VERBS,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
-        runner.add<fp::MXLHost2Host<"MXLHost2Host+Verbs+OneWay+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_VERBS,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
-        runner.add<fp::MXLHost2Host<"MXLHost2Host+TCP+Reflect+Wait", fp::TransferMode::Reflect, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_TCP,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
-        runner.add<fp::MXLHost2Host<"MXLHost2Host+TCP+Reflect+Spin", fp::TransferMode::Reflect, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_TCP,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
-        runner.add<fp::MXLHost2Host<"MXLHost2Host+TCP+OneWay+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_TCP,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
-        runner.add<fp::MXLHost2Host<"MXLHost2Host+TCP+OneWay+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_TCP,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
-        runner.add<fp::MXLHost2Host<"MXLCuda2Cuda+Verbs+Oneway+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_VERBS, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
-        runner.add<fp::MXLHost2Host<"MXLCuda2Cuda+Verbs+Oneway+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_VERBS, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
-        runner.add<fp::MXLHost2Host<"MXLCuda2Cuda+Verbs+Reflect+Wait", fp::TransferMode::Reflect, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_VERBS, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
-        runner.add<fp::MXLHost2Host<"MXLCuda2Cuda+Verbs+Reflect+Spin", fp::TransferMode::Reflect, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_VERBS, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
-        runner.add<fp::MXLHost2Host<"MXLHost2Cuda+SHM+Oneway+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_CUDA>>();
-        runner.add<fp::MXLHost2Host<"MXLHost2Cuda+SHM+Oneway+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_CUDA>>();
-        runner.add<fp::MXLHost2Host<"MXLCuda2Host+SHM+Oneway+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_HOST>>();
-        runner.add<fp::MXLHost2Host<"MXLCuda2Host+SHM+Oneway+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_HOST>>();
-        runner.add<fp::MXLHost2Host<"MXLCuda2Cuda+SHM+Oneway+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
-        runner.add<fp::MXLHost2Host<"MXLCuda2Cuda+SHM+Oneway+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
-        runner.add<fp::MXLHost2Host<"MXLCuda2Cuda+SHM+Reflect+Wait", fp::TransferMode::Reflect, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
-        runner.add<fp::MXLHost2Host<"MXLCuda2Cuda+SHM+Reflect+Spin", fp::TransferMode::Reflect, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Host2Host+Verbs+Reflect+Wait", fp::TransferMode::Reflect, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_VERBS, MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Host2Host+Verbs+Reflect+Spin", fp::TransferMode::Reflect, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_VERBS,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Host2Host+Verbs+OneWay+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_VERBS,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Host2Host+Verbs+OneWay+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_VERBS,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Host2Host+TCP+Reflect+Wait", fp::TransferMode::Reflect, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_TCP,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Host2Host+TCP+Reflect+Spin", fp::TransferMode::Reflect, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_TCP,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Host2Host+TCP+OneWay+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_TCP,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Host2Host+TCP+OneWay+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_TCP,MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_HOST>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Cuda2Cuda+Verbs+Oneway+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_VERBS, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Cuda2Cuda+Verbs+Oneway+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_VERBS, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Cuda2Cuda+Verbs+Reflect+Wait", fp::TransferMode::Reflect, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_VERBS, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Cuda2Cuda+Verbs+Reflect+Spin", fp::TransferMode::Reflect, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_VERBS, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Host2Cuda+SHM+Oneway+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_CUDA>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Host2Cuda+SHM+Oneway+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_HOST, MXL_MEMORY_REGION_TYPE_CUDA>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Cuda2Host+SHM+Oneway+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_HOST>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Cuda2Host+SHM+Oneway+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_HOST>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Cuda2Cuda+SHM+Oneway+Wait", fp::TransferMode::OneWay, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Cuda2Cuda+SHM+Oneway+Spin", fp::TransferMode::OneWay, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Cuda2Cuda+SHM+Reflect+Wait", fp::TransferMode::Reflect, fp::PollMode::WAIT, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
+        runner.add<fp::MXLFabrics<"MXLFabrics+Cuda2Cuda+SHM+Reflect+Spin", fp::TransferMode::Reflect, fp::PollMode::SPIN, MXL_SHARING_PROVIDER_SHM, MXL_MEMORY_REGION_TYPE_CUDA, MXL_MEMORY_REGION_TYPE_CUDA>>();
         runner.add<fp::OneWayTest>();
         runner.add<fp::PingPongTest>();
         //clang-format on

--- a/src/tests/MXLFabrics.hpp
+++ b/src/tests/MXLFabrics.hpp
@@ -23,17 +23,17 @@ namespace riedel::fabricsperf
 
     template<StaticString, TransferMode, PollMode, mxlFabricsProvider, mxlFabricsMemoryRegionType,
         mxlFabricsMemoryRegionType>
-    class MXLHost2Host;
+    class MXLFabrics;
 
     template<StaticString Name, TransferMode TM, PollMode Poll, mxlFabricsProvider Provider,
         mxlFabricsMemoryRegionType InitiatorLocation, mxlFabricsMemoryRegionType TargetLocation>
-    class MXLHost2HostFactory : public TestFactory
+    class MXLFabricsFactory : public TestFactory
     {
     public:
         std::unique_ptr<Test> operator()() const final
         {
             return std::make_unique<
-                MXLHost2Host<Name, TM, Poll, Provider, InitiatorLocation, TargetLocation>>();
+                MXLFabrics<Name, TM, Poll, Provider, InitiatorLocation, TargetLocation>>();
         }
 
         [[nodiscard]]
@@ -45,11 +45,11 @@ namespace riedel::fabricsperf
 
     template<StaticString Name, TransferMode TM, PollMode Poll, mxlFabricsProvider Provider,
         mxlFabricsMemoryRegionType InitiatorLocation, mxlFabricsMemoryRegionType TargetLocation>
-    class MXLHost2Host : public Test
+    class MXLFabrics : public Test
     {
     public:
         using Factory =
-            MXLHost2HostFactory<Name, TM, Poll, Provider, InitiatorLocation, TargetLocation>;
+            MXLFabricsFactory<Name, TM, Poll, Provider, InitiatorLocation, TargetLocation>;
         constexpr static int numWarmupIterations = 200;
 
         bool runInitiator(TestContext const& ctx)


### PR DESCRIPTION
- Rename MXLHost2Host to MXLFabrics
- Changed the `run` parameter so it can take multiple testcases separated by spaces.
- Remove the `all` value for the `run` parameter, because it doesn't make sense anymore since the introduction of the SHM provider
- When `run` is empty on the runner it will list the testcases and it is ignored on the reflector